### PR TITLE
Grammar fixes in type-checking.md

### DIFF
--- a/docs/type-checking.md
+++ b/docs/type-checking.md
@@ -8,7 +8,7 @@ If we can declare functions with Rust that can be called from JS then we need to
 
 ## Upcasting
 
-Every method of a JS class implicity returns a `JsValue` function returns a `JsValue`. No type more or less specific than a `JsValue` can be returned:
+Every method of a JS class implicity returns a `JsValue`. No type more or less specific than a `JsValue` can be returned.
 
 For example, the following class method would fail to compile:
 


### PR DESCRIPTION
As the title suggests :)

The remainder of the section is unfortunately still quite unclear; the example code isn't really explained in any way, and the text below the example looks like placeholder text, but I don't know enough about Neon yet to fix those.