### PR TITLE
fix arguments doc

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -26,7 +26,7 @@ The following code takes the first argument passed to the `sayHi` function and t
 
 ```rust
 fn say_hi(mut cx: FunctionContext) -> JsResult<JsFunction> {
-    let arg0 = cx.argument::<JsFunction>(0)?.value();
+    let arg0 = cx.argument::<JsFunction>(0)?;
     // --snip--
 }
 ```


### PR DESCRIPTION
It does not really work like that:

```
error[E0599]: no method named `value` found for type `neon::handle::Handle<'_, neon::types::JsFunction>` in the current scope
 --> src/lib.rs:8:43
  |
8 |     let x = cx.argument::<JsFunction>(0)?.value();
  |                                           ^^^^^ private field, not a method

error: aborting due to previous error

For more information about this error, try `rustc --explain E0599`.
error: Could not compile `hello-world`.

To learn more, run the command again with --verbose.
neon ERR! cargo build failed

Error: cargo build failed
```