### PR TITLE
Fix build command in electron-apps.md

### DIFF
--- a/docs/electron-apps.md
+++ b/docs/electron-apps.md
@@ -47,7 +47,7 @@ Finally, we'll add a script to build the Neon dependency:
 ```jsonc
 "scripts": {
     // ...
-    "build": "electron-build-env neon build neon-hello --release"
+    "build": "electron-build-env neon build @amilajack/neon-hello --release"
     // ...
 }
 ```


### PR DESCRIPTION
The working [example project on github](https://github.com/neon-bindings/examples/blob/master/electron-app/package.json) uses the following build command:

`electron-build-env neon build @amilajack/neon-hello --release`

But the snippet in the docs example uses:

`electron-build-env neon build neon-hello --release`

which doesn't work on my system.

This pull request changes `neon-hello` to `@amilajack/neon-hello` to match the code on Github / fix the docs snippet.