### PR TITLE
Fix broken link to GitHub

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,4 +1,9 @@
+const CORE_REPO_URL = "https://github.com/neon-bindings/neon";
+
 module.exports = {
+  customFields: {
+    coreRepoUrl: CORE_REPO_URL,
+  },
   title: "Neon",
   tagline: "Fast and Safe Native Node.js Modules",
   url: "https://neon-bindings.com",
@@ -42,7 +47,7 @@ module.exports = {
         { position: "left", to: "blog", label: "Blog" },
         {
           position: "left",
-          href: "https://github.com/neon-bindings/neon",
+          href: CORE_REPO_URL,
           label: "GitHub",
         },
       ],
@@ -90,7 +95,7 @@ module.exports = {
           items: [
             {
               label: "GitHub",
-              to: "https://github.com/neon-bindings/neon",
+              to: CORE_REPO_URL,
             },
           ],
         },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -184,6 +184,7 @@ const cStyles = (_styles) => _styles.join(" ");
 function Home() {
   const context = useDocusaurusContext();
   const { siteConfig = {} } = context;
+  const repoUrl = "https://github.com/neon-bindings/neon";
 
   return (
     <Layout
@@ -209,7 +210,7 @@ function Home() {
                 <a href={useBaseUrl("docs/getting-started")}>
                   <Button color="primary">Try It Out</Button>
                 </a>
-                <a href={siteConfig.repoUrl}>
+                <a href={repoUrl}>
                   <Button color="primary" target="_blank">
                     GitHub
                   </Button>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -184,7 +184,6 @@ const cStyles = (_styles) => _styles.join(" ");
 function Home() {
   const context = useDocusaurusContext();
   const { siteConfig = {} } = context;
-  const repoUrl = "https://github.com/neon-bindings/neon";
 
   return (
     <Layout
@@ -210,7 +209,7 @@ function Home() {
                 <a href={useBaseUrl("docs/getting-started")}>
                   <Button color="primary">Try It Out</Button>
                 </a>
-                <a href={repoUrl}>
+                <a href={siteConfig.customFields.coreRepoUrl}>
                   <Button color="primary" target="_blank">
                     GitHub
                   </Button>


### PR DESCRIPTION
- Link to GitHub is broken on https://neon-bindings.com. This should fix it
- `siteConfig.repoUrl` is undefined and can't be placed in `docusaurus.config.js`. 