### PR TITLE
Fix the capitalization of Rust

### DIFF
--- a/docs/arrays.md
+++ b/docs/arrays.md
@@ -8,7 +8,7 @@ sidebar_label: Arrays
 
 ## Converting from `Vec` to `JsArray`
 
-Here is a simple example of converting a rust `Vec` to a JS `Array` using `JsArray`:
+Here is a simple example of converting a Rust `Vec` to a JS `Array` using `JsArray`:
 
 ```rust
 fn convert_vec_to_array(mut cx: FunctionContext) -> JsResult<JsArray> {
@@ -17,7 +17,7 @@ fn convert_vec_to_array(mut cx: FunctionContext) -> JsResult<JsArray> {
     // Create the JS array
     let js_array = JsArray::new(&mut cx, vec.len() as u32);
 
-    // Iterate over the rust Vec and map each value in the Vec to the JS array
+    // Iterate over the Rust Vec and map each value in the Vec to the JS array
     for (i, obj) in vec.iter().enumerate() {
         let js_string = cx.string(obj);
         js_array.set(&mut cx, i as u32, js_string).unwrap();

--- a/docs/example-projects.md
+++ b/docs/example-projects.md
@@ -16,7 +16,7 @@ Here is a list of projects using Neon
 - [libsodium-neon: Node bindings to libsodium](https://github.com/wireapp/libsodium-neon)
 - [ledb: Lightweight embedded database](https://github.com/katyo/ledb)
 - [node-crypto: rust-crypto bindings for Node](https://github.com/Brooooooklyn/node-crypto)
-- [os-type: Bindings to the os_type rust library](https://github.com/amilajack/os-type)
+- [os-type: Bindings to the os_type Rust library](https://github.com/amilajack/os-type)
 - [node-webrender: bindings to webrender](https://github.com/cztomsik/node-webrender)
 
 And <a href="https://www.npmjs.com/browse/depended/neon-cli" target="_blank">many more!</a>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -107,7 +107,7 @@ const features = [
     description: (
       <>
         If a neon module compiles, it is guaranteed to be memory safe by the
-        rust compiler
+        Rust compiler
       </>
     ),
     imageUrl: "img/checkmark.svg",


### PR DESCRIPTION
I've just noticed the word "Rust", as a proper noun, is not capitalized at a few places in the documentation (including the front page).