### PR TITLE
Fixing some syntax in vec_to_array() example.

### DIFF
--- a/docs/arrays.md
+++ b/docs/arrays.md
@@ -72,11 +72,11 @@ An iterable Rust data structure such as `Vec` can be converted to a JavaScript a
 
 ```rust
 fn vec_to_array<'a, C: Context<'a>>(vec: &Vec<String>, cx: &mut C) -> JsResult<'a, JsArray> {
-    let a = JsArray::new(cx, vec.len());
+    let a = JsArray::new(cx, vec.len() as u32);
 
     for (i, s) in vec.iter().enumerate() {
         let v = cx.string(s);
-        a.set(&mut cx, i as u32, v)?;
+        a.set(cx, i as u32, v)?;
     }
 
     Ok(a)


### PR DESCRIPTION
I ran into some small issues with this example. Fixing, as discussed in Slack at https://rust-bindings.slack.com/archives/C0H978T55/p1637270887070500.