### PR TITLE
Update footer to point to the main examples

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -66,7 +66,7 @@ module.exports = {
             },
             {
               label: "Examples",
-              to: "https://github.com/neon-bindings/examples/tree/legacy#table-of-contents",
+              to: "https://github.com/neon-bindings/examples/tree/main#table-of-contents",
             },
             {
               label: "API Reference",


### PR DESCRIPTION
The website footer still links to the legacy examples; this PR updates it to point to the main branch of the examples repo.