### PR TITLE
Modern function call syntax

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -137,7 +137,7 @@ let x: Handle<JsNumber> = parse_int
     .apply(&mut cx)?;
 ```
 
-The `parse_int.call_with()` takes a runtime context and produces a [`CallOptions`](https://docs.rs/neon/latest/neon/types/function/struct.CallOptions.html) struct that can be used to specify the arguments to the function. In this case, we specify just one argument: a JavaScript string constructed from the Rust string `"42"`.
+The `parse_int.call_with()` method takes a runtime context and produces a [`CallOptions`](https://docs.rs/neon/latest/neon/types/function/struct.CallOptions.html) struct that can be used to specify the arguments to the function. In this case, we specify just one argument: a JavaScript string constructed from the Rust string `"42"`.
 
 ## Calling Constructor Functions
 
@@ -153,3 +153,5 @@ let obj = url
     .arg(cx.string("https://neon-bindings.com"))
     .apply(&mut cx)?;
 ```
+
+Similar to `call_with()` above, the `url.construct_with()` method takes a runtime context and produces a [`ConstructOptions`](https://docs.rs/neon/latest/neon/types/function/struct.ConstructOptions.html) struct that can be used to specify the arguments to the constructor call. In this case, we specify just one argument: a JavaScript string constructed from the Rust string `"https://neon-bindings.com"`.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -12,7 +12,7 @@ Neon is a library and toolchain for embedding [Rust](https://www.rust-lang.org/e
 
 ## Why Neon?
 
-With Neon, you can create native Node modules like you might in C or C++, but with none of the fear and headaches associated with unsafe systems programming. Embedding Rust in Node can be useful for many reasons:
+With Neon, you can create native Node modules like you might in C or C++, but with none of the headaches and anxiety associated with unsafe systems programming. Embedding Rust in Node can be useful for many reasons:
 
 - Raw performance
 - Threads and parallel programming


### PR DESCRIPTION
Update functions how-to with modern `call_with` and `construct_with` syntax.

Also a minor copy-edit in the intro.

**Testing:** manually tested every link in the Netlify preview to ensure there were no broken links introduced.