### PR TITLE
Adding Dashlane to the example projects

### DIFF
--- a/docs/example-projects.md
+++ b/docs/example-projects.md
@@ -12,6 +12,7 @@ Neon is used to power a growing community of applications and libraries—maybe 
 - **[Signal:](https://github.com/signalapp/libsignal-client)** Secure, private messaging
 - **[Finda:](https://keminglabs.com/finda/)** Type stuff, find things. No mousing.
 - **[Parsify Desktop:](https://parsify.app)** Extendable notepad calculator for the 21st Century.
+- **[Dashlane:](https://www.dashlane.com/)** Secure password manager
 
 ## Node Libraries
 


### PR DESCRIPTION
At Dashlane we're using neon-bindings to integrate Rust modules into our server API.

We will be publishing our sources in the upcoming months and I'll update the link to show the specific parts of the code using it.

Thanks for your work!
