### PR TITLE
Add missing step for hello-world tutorial

### DIFF
--- a/docs/hello-world.md
+++ b/docs/hello-world.md
@@ -49,6 +49,7 @@ We haven't yet implemented anything, but just to see that `npm init neon` produc
 ```shell
 cd cpu-count
 npm install
+npm run cargo-build -- --release
 ```
 
 The build process generates a handful of files:


### PR DESCRIPTION
Without the cargo build step, the library is not made available for `require` in the `node` repl